### PR TITLE
feat: add basic event creation and storage

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -7,10 +7,10 @@
 - [x] Set up Playwright smoke test verifying the app loads and displays.
 
 ## Milestone 2: Event Creation
-- [ ] Define event data model (date and description).
-- [ ] Build form to add new events.
-- [ ] Persist events in browser local storage.
-- [ ] Render saved events on the timeline.
+- [x] Define event data model (date and description).
+- [x] Build form to add new events.
+- [x] Persist events in browser local storage.
+- [x] Render saved events on the timeline.
 
 ## Milestone 3: Event Editing & Deletion
 - [ ] Select an event to modify its text or date.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,76 @@
+import { useEffect, useState } from 'react';
 import Timeline from './components/Timeline';
+import type { Event } from './types';
+
+const STORAGE_KEY = 'chronochart-events';
 
 function App() {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [date, setDate] = useState('');
+  const [title, setTitle] = useState('');
+
+  // Load events from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setEvents(JSON.parse(stored));
+      } catch {
+        /* ignore malformed data */
+      }
+    }
+  }, []);
+
+  // Persist events whenever they change
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+  }, [events]);
+
+  function addEvent(e: React.FormEvent) {
+    e.preventDefault();
+    if (!date || !title) return;
+    const newEvent: Event = {
+      id: Date.now().toString(),
+      date,
+      title,
+    };
+    setEvents((prev) => [...prev, newEvent]);
+    setDate('');
+    setTitle('');
+  }
+
   return (
     <main className="min-h-screen flex flex-col items-center justify-center gap-6 p-6">
       <h1 className="text-3xl font-bold">Chronochart</h1>
-      <Timeline />
+      <form onSubmit={addEvent} className="flex flex-wrap items-end gap-2">
+        <label className="flex flex-col text-sm">
+          <span>Date</span>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="rounded border px-2 py-1 text-black"
+            required
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          <span>Title</span>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="rounded border px-2 py-1 text-black"
+            required
+          />
+        </label>
+        <button
+          type="submit"
+          className="rounded bg-indigo-600 px-3 py-1 text-white"
+        >
+          Add
+        </button>
+      </form>
+      <Timeline events={events} />
     </main>
   );
 }

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,6 +1,16 @@
 import React from 'react';
+import type { Event } from '../types';
 
-const Timeline: React.FC = () => {
+interface Props {
+  events: Event[];
+}
+
+const Timeline: React.FC<Props> = ({ events }) => {
+  const sorted = [...events].sort((a, b) => a.date.localeCompare(b.date));
+  const min = sorted.length ? new Date(sorted[0].date).getTime() : 0;
+  const max = sorted.length ? new Date(sorted[sorted.length - 1].date).getTime() : 0;
+  const range = max - min || 1;
+
   return (
     <div className="w-full flex items-center justify-center" style={{ minHeight: 160 }}>
       <svg
@@ -17,7 +27,10 @@ const Timeline: React.FC = () => {
           </linearGradient>
         </defs>
         <line x1="0" y1="5" x2="100" y2="5" stroke="url(#timelineGradient)" strokeWidth="3" strokeLinecap="round" />
-        <circle cx="50" cy="5" r="4" fill="#ffffff" stroke="#6d28d9" strokeWidth="1" />
+        {sorted.map((ev) => {
+          const x = ((new Date(ev.date).getTime() - min) / range) * 100;
+          return <rect key={ev.id} x={x - 1} y={4} width={2} height={2} fill="#fff" stroke="#6d28d9" strokeWidth={0.5} />;
+        })}
       </svg>
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,6 @@
+export interface Event {
+  id: string;
+  date: string;
+  title: string;
+  description?: string;
+}


### PR DESCRIPTION
## Summary
- define an event type for timeline items
- add event creation form with localStorage persistence
- render stored events as nodes on the timeline

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist; attempted `npx playwright install` but downloads returned 403 domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68976bcacf30833298afe1959a9292f4